### PR TITLE
Add optional, off-by-default historical base-rate grounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,49 @@ Example `appsettings.json`:
 }
 ```
 
+### Optional: Historical Base-Rate Grounding (off by default)
+
+The agents can optionally be **grounded** in historical base rates from [Chart Library](https://chartlibrary.io). For the `(ticker, decision date)` an agent is evaluating, it looks up the calibrated forward-return distribution of historically analogous setups and adds one plain-English line of context to the agent's reasoning. It is **purely advisory**: it never changes an agent's buy/hold/sell signal or confidence, and when a signal runs counter to a clearly-signed base rate it appends a one-line reality-check note only.
+
+This feature is **off by default** and fully **degrade-safe** — if it is disabled, unconfigured, or the endpoint is slow/unreachable, the program behaves exactly as it does today (the lookup returns nothing and never throws or blocks the trading flow).
+
+To enable it, add a `Grounding` section to `appsettings.json` and supply a Chart Library API key:
+
+```json
+{
+  "Grounding": {
+    "Enabled": true,
+    "ApiKey": "your-chartlibrary-api-key",
+    "BaseUrl": "https://chartlibrary.io",
+    "Timeframe": "rth",
+    "Horizons": [ 1, 5, 10 ],
+    "OverfitHorizon": 5,
+    "TimeoutSeconds": 8,
+    "ExcludeSameSymbolDays": true
+  }
+}
+```
+
+Grounding only activates when **both** `Enabled` is `true` **and** an API key is present. The key and base URL can also be supplied via environment variables (handy for CI/containers), which override `appsettings.json`:
+
+```bash
+export CHART_LIBRARY_API_KEY=your-chartlibrary-api-key
+export CHART_LIBRARY_API_URL=https://chartlibrary.io   # optional
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `Enabled` | `false` | Master switch; grounding is a no-op unless `true` **and** a key is set |
+| `ApiKey` | _(none)_ | Chart Library API key (or the `CHART_LIBRARY_API_KEY` env var) |
+| `BaseUrl` | `https://chartlibrary.io` | API base URL (or the `CHART_LIBRARY_API_URL` env var) |
+| `Timeframe` | `rth` | Bar timeframe to anchor on |
+| `Horizons` | `[1, 5, 10]` | Forward-return horizons (days) requested |
+| `OverfitHorizon` | `5` | Which horizon's band is surfaced to the agent |
+| `TimeoutSeconds` | `8` | Per-lookup HTTP timeout; on timeout the lookup is skipped |
+| `ExcludeSameSymbolDays` | `true` | Exclude the same symbol's own history from the cohort |
+
+> Anchoring uses **no lookahead**: the base rate for a ticker is anchored on the latest priced bar (the decision date), and the historical cohort is drawn only from earlier data.
+
 ---
 
 ## Cache

--- a/src/AiHedgeFund.Agents/BenGrahamAgent.cs
+++ b/src/AiHedgeFund.Agents/BenGrahamAgent.cs
@@ -38,7 +38,7 @@ public class BenGrahamAgent : IAgent
         var totalScore = earnings.Score + strength.Score + valuation.Score;
         var maxScore = Math.Max(1, earnings.MaxScore + strength.MaxScore + valuation.MaxScore);
 
-        if (TryGenerateOutput(ticker, totalScore, maxScore, earnings, strength, valuation, input.Model, out var tradeSignal))
+        if (TryGenerateOutput(ticker, totalScore, maxScore, earnings, strength, valuation, input.Model, input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal, new[] { earnings, strength, valuation });
 
         _logger.LogError("Error while running {AgentName}", nameof(BenGrahamAgent));
@@ -262,7 +262,7 @@ public class BenGrahamAgent : IAgent
     }
 
     private bool TryGenerateOutput(string ticker, int totalScore, int maxScore, FinancialAnalysisResult earnings,
-        FinancialAnalysisResult strength, FinancialAnalysisResult valuation, string model, out TradeSignal tradeSignal)
+        FinancialAnalysisResult strength, FinancialAnalysisResult valuation, string model, BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         if (string.IsNullOrWhiteSpace(ticker))
         {
@@ -296,7 +296,8 @@ public class BenGrahamAgent : IAgent
             analysisData,
             agentName: "Ben Graham",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Agents/BillAckmanAgent.cs
+++ b/src/AiHedgeFund.Agents/BillAckmanAgent.cs
@@ -46,7 +46,7 @@ public class BillAckmanAgent : IAgent
         var maxScore = Math.Max(1, businessQuality.MaxScore + financialDiscipline.MaxScore + valuation.MaxScore);
 
         if (TryGenerateOutput(ticker, businessQuality, financialDiscipline, valuation, totalScore, maxScore,
-                input.Model, out var tradeSignal))
+                input.Model, input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal,
                 new[] { businessQuality, financialDiscipline, valuation });
 
@@ -330,7 +330,7 @@ public class BillAckmanAgent : IAgent
 
     private bool TryGenerateOutput(string ticker, FinancialAnalysisResult businessQuality,
         FinancialAnalysisResult financialDiscipline, FinancialAnalysisResult valuation, int totalScore, int maxScore,
-        string model, out TradeSignal tradeSignal)
+        string model, BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         var systemMessage = """
         You are a Bill Ackman AI agent, making investment decisions using his principles:
@@ -369,7 +369,8 @@ public class BillAckmanAgent : IAgent
             analysisData,
             agentName: "Bill Ackman",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Agents/CathieWoodAgent.cs
+++ b/src/AiHedgeFund.Agents/CathieWoodAgent.cs
@@ -49,7 +49,7 @@ public class CathieWoodAgent : IAgent
         var maxScore = Math.Max(1, disruptive.MaxScore + innovation.MaxScore + valuation.MaxScore);
 
         if (TryGenerateOutput(input.Model, ticker, disruptive, innovation, valuation, totalScore, maxScore,
-                out var tradeSignal))
+                input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal,
                 new[] { disruptive, innovation, valuation });
 
@@ -283,7 +283,7 @@ public class CathieWoodAgent : IAgent
 
     private bool TryGenerateOutput(string model, string ticker, FinancialAnalysisResult disruptive,
         FinancialAnalysisResult innovation, FinancialAnalysisResult valuation, decimal totalScore, int maxScore,
-        out TradeSignal tradeSignal)
+        BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         var systemMessage = @"You are a Cathie Wood AI agent, making investment decisions using her principles:
 1. Seek companies leveraging disruptive innovation.
@@ -317,7 +317,8 @@ Rules:
             analysisData,
             agentName: "Cathie Wood",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Agents/CharlieMungerAgent.cs
+++ b/src/AiHedgeFund.Agents/CharlieMungerAgent.cs
@@ -52,7 +52,7 @@ public class CharlieMungerAgent : IAgent
             valuation.MaxScore);
 
         if (TryGenerateOutput(input.Model, ticker, moatStrength, managementQuality, predictability, companyNews,
-                valuation, totalScore, maxScore, out var tradeSignal))
+                valuation, totalScore, maxScore, input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal,
                 new[] { moatStrength, managementQuality, predictability, companyNews, valuation });
 
@@ -900,7 +900,7 @@ public class CharlieMungerAgent : IAgent
     private bool TryGenerateOutput(string model, string ticker, FinancialAnalysisResult analysisResult,
         FinancialAnalysisResult financialAnalysisResult, FinancialAnalysisResult businessQuality,
         FinancialAnalysisResult companyNews, FinancialAnalysisResult valuation, int totalScore, int maxScore,
-        out TradeSignal tradeSignal)
+        BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         tradeSignal = default!;
 
@@ -948,7 +948,8 @@ Rules:
             analysisData,
             agentName: "Charlie Munger",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Agents/Services/LlmTradeSignalGenerator.cs
+++ b/src/AiHedgeFund.Agents/Services/LlmTradeSignalGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.RegularExpressions;
 using AiHedgeFund.Contracts;
+using AiHedgeFund.Contracts.Model;
 
 namespace AiHedgeFund.Agents.Services;
 
@@ -14,15 +15,24 @@ public static class LlmTradeSignalGenerator
         object analysisData,
         string agentName,
         out TradeSignal tradeSignal,
-        string model = "gpt-4o-mini")
+        string model = "gpt-4o-mini",
+        BaseRate? baseRate = null)
     {
         tradeSignal = default!;
+
+        // Off-by-default grounding: when a base rate is supplied, give the model the
+        // realized forward-return distribution of analogous historical setups as context
+        // to reason WITH. It is advisory only and never forces a particular signal.
+        var grounding = baseRate is null
+            ? string.Empty
+            : "\n\nHistorical base-rate context (advisory — realized outcomes of analogous "
+              + $"past setups, not a forecast):\n{baseRate.ToContextLine()}\n";
 
         var userMessage = $@"Based on the following analysis, create a {agentName}-style investment signal:
 
 Analysis Data for {ticker}:
 {JsonSerializer.Serialize(analysisData, new JsonSerializerOptions { WriteIndented = true })}
-
+{grounding}
 Return JSON exactly in this format:
 {{
   ""signal"": ""bullish"" or ""bearish"" or ""neutral"",

--- a/src/AiHedgeFund.Agents/Services/PortfolioManager.cs
+++ b/src/AiHedgeFund.Agents/Services/PortfolioManager.cs
@@ -8,11 +8,14 @@ public class PortfolioManager
 {
     private readonly ILogger<PortfolioManager> _logger;
     private readonly IAgentRegistry _agentRegistry;
+    private readonly IBaseRateProvider? _baseRateProvider;
 
-    public PortfolioManager(IAgentRegistry agentRegistry, ILogger<PortfolioManager> logger)
+    public PortfolioManager(IAgentRegistry agentRegistry, ILogger<PortfolioManager> logger,
+        IBaseRateProvider? baseRateProvider = null)
     {
         _agentRegistry = agentRegistry;
         _logger = logger;
+        _baseRateProvider = baseRateProvider;
     }
 
     public IReadOnlyList<AgentResult> Evaluate(string agentKey, TradingWorkflowState state)
@@ -44,13 +47,42 @@ public class PortfolioManager
                 Metrics: metrics,
                 LineItems: lineItems,
                 Prices: prices ?? Enumerable.Empty<Price>(),
-                News: news ?? Enumerable.Empty<NewsSentiment>()
+                News: news ?? Enumerable.Empty<NewsSentiment>(),
+                BaseRate: TryGetBaseRate(ticker, prices, state)
             );
 
-            results.Add(agent.Analyze(input));
+            var result = agent.Analyze(input);
+            AppendBaseRateAdvisory(input.BaseRate, result);
+            results.Add(result);
         }
 
         return results;
+    }
+
+    private BaseRate? TryGetBaseRate(string ticker, IEnumerable<Price>? prices, TradingWorkflowState state)
+    {
+        if (_baseRateProvider is not { Enabled: true })
+            return null;
+
+        // No-lookahead: anchor on the latest priced bar (the decision date), falling back
+        // to the workflow end date. The historical cohort is drawn only from earlier bars.
+        var asOf = prices?.MaxBy(p => p.Date)?.Date ?? state.EndDate;
+        return _baseRateProvider.TryGetBaseRate(ticker, asOf, out var baseRate) ? baseRate : null;
+    }
+
+    private static void AppendBaseRateAdvisory(BaseRate? baseRate, AgentResult result)
+    {
+        if (baseRate is null || result.Signal is null)
+            return;
+
+        // Advisory only: flag when the signal runs counter to a clearly-signed base rate.
+        // The signal itself is never altered.
+        var note = baseRate.AssessConflict(result.Signal.Signal);
+        if (string.IsNullOrEmpty(note))
+            return;
+
+        var reasoning = result.Signal.Reasoning;
+        result.Signal.Reasoning = string.IsNullOrWhiteSpace(reasoning) ? note : $"{reasoning}\n\n{note}";
     }
 
     public void RunRiskAssessments(TradingWorkflowState state, RiskManagerAgent riskAgent,

--- a/src/AiHedgeFund.Agents/StanleyDruckenmillerAgent.cs
+++ b/src/AiHedgeFund.Agents/StanleyDruckenmillerAgent.cs
@@ -49,7 +49,7 @@ public class StanleyDruckenmillerAgent : IAgent
 
         const int maxScore = 10;
 
-        if (TryGenerateOutput(ticker, growthMomentum, riskReward, valuation, sentiment, insiderActivity, totalScore, maxScore, input.Model, out var tradeSignal))
+        if (TryGenerateOutput(ticker, growthMomentum, riskReward, valuation, sentiment, insiderActivity, totalScore, maxScore, input.Model, input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal,
                 new[] { growthMomentum, riskReward, sentiment, insiderActivity, valuation });
 
@@ -476,7 +476,7 @@ public class StanleyDruckenmillerAgent : IAgent
 
     private bool TryGenerateOutput(string ticker, FinancialAnalysisResult growthMomentum,
         FinancialAnalysisResult riskReward, FinancialAnalysisResult valuation, FinancialAnalysisResult sentiment,
-        FinancialAnalysisResult insiderActivity, double totalScore, int maxScore, string model, out TradeSignal tradeSignal)
+        FinancialAnalysisResult insiderActivity, double totalScore, int maxScore, string model, BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         tradeSignal = default!;
 
@@ -515,7 +515,8 @@ Rules:
             analysisData: analysisData,
             agentName: "Stanley Druckenmiller",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Agents/WarrenBuffettAgent.cs
+++ b/src/AiHedgeFund.Agents/WarrenBuffettAgent.cs
@@ -41,7 +41,7 @@ public class WarrenBuffettAgent : IAgent
         var totalScore = fundamentals.Score + consistency.Score + valuation.Score;
         var maxScore = fundamentals.MaxScore + consistency.MaxScore + valuation.MaxScore;
 
-        if (TryGenerateOutput(ticker, fundamentals, consistency, valuation, totalScore, maxScore, input.Model, out var tradeSignal))
+        if (TryGenerateOutput(ticker, fundamentals, consistency, valuation, totalScore, maxScore, input.Model, input.BaseRate, out var tradeSignal))
             return new AgentResult(Key, DisplayName, ticker, tradeSignal, new[] { fundamentals, consistency, valuation });
 
         _logger.LogError($"Error while generating signal for {ticker}");
@@ -369,7 +369,7 @@ public class WarrenBuffettAgent : IAgent
 
     private bool TryGenerateOutput(string ticker, FinancialAnalysisResult fundamentals,
         FinancialAnalysisResult consistency, FinancialAnalysisResult valuationSummary, double totalScore, int maxScore,
-        string model, out TradeSignal tradeSignal)
+        string model, BaseRate? baseRate, out TradeSignal tradeSignal)
     {
         tradeSignal = default!;
 
@@ -408,7 +408,8 @@ public class WarrenBuffettAgent : IAgent
             analysisData: analysisData,
             agentName: "Warren Buffett",
             out tradeSignal,
-            model: model
+            model: model,
+            baseRate: baseRate
         );
     }
 }

--- a/src/AiHedgeFund.Console/Program.cs
+++ b/src/AiHedgeFund.Console/Program.cs
@@ -5,6 +5,7 @@ using AiHedgeFund.Agents.Services;
 using AiHedgeFund.Contracts;
 using AiHedgeFund.Data;
 using AiHedgeFund.Data.AlphaVantage;
+using AiHedgeFund.Data.ChartLibrary;
 using AiHedgeFund.Data.Mock;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,6 +62,25 @@ internal class Program
                         throw new InvalidOperationException("OpenAI API key is missing in configuration.");
                     client.BaseAddress = new Uri("https://api.openai.com/v1/");
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                });
+
+                // Optional historical base-rate grounding (off by default). Only does anything
+                // when the "Grounding" section sets Enabled=true AND a key is present (config or
+                // the CHART_LIBRARY_API_KEY environment variable). Otherwise it is a clean no-op.
+                var grounding = configuration.GetSection(GroundingOptions.SectionName).Get<GroundingOptions>()
+                                ?? new GroundingOptions();
+                var groundingKey = Environment.GetEnvironmentVariable("CHART_LIBRARY_API_KEY");
+                if (!string.IsNullOrWhiteSpace(groundingKey))
+                    grounding.ApiKey = groundingKey;
+                var groundingUrl = Environment.GetEnvironmentVariable("CHART_LIBRARY_API_URL");
+                if (!string.IsNullOrWhiteSpace(groundingUrl))
+                    grounding.BaseUrl = groundingUrl;
+                services.AddSingleton(grounding);
+                services.AddSingleton<IBaseRateProvider, ChartLibraryBaseRateProvider>();
+                services.AddHttpClient("ChartLibrary", client =>
+                {
+                    client.BaseAddress = new Uri(grounding.BaseUrl.TrimEnd('/') + "/");
+                    client.Timeout = TimeSpan.FromSeconds(grounding.TimeoutSeconds <= 0 ? 8.0 : grounding.TimeoutSeconds);
                 });
             })
             .ConfigureLogging(logging =>

--- a/src/AiHedgeFund.Contracts/AgentInput.cs
+++ b/src/AiHedgeFund.Contracts/AgentInput.cs
@@ -10,5 +10,6 @@ public record AgentInput(
     IEnumerable<FinancialMetrics> Metrics,
     IEnumerable<FinancialLineItem> LineItems,
     IEnumerable<Price> Prices,
-    IEnumerable<NewsSentiment> News
+    IEnumerable<NewsSentiment> News,
+    BaseRate? BaseRate = null
 );

--- a/src/AiHedgeFund.Contracts/IBaseRateProvider.cs
+++ b/src/AiHedgeFund.Contracts/IBaseRateProvider.cs
@@ -1,0 +1,15 @@
+using AiHedgeFund.Contracts.Model;
+
+namespace AiHedgeFund.Contracts;
+
+/// <summary>
+/// Supplies optional historical base-rate grounding for a (symbol, date). Implementations
+/// must be degrade-safe: a failed lookup returns false and a null base rate, never throws,
+/// and never blocks the trading flow. When <see cref="Enabled"/> is false the provider is a no-op.
+/// </summary>
+public interface IBaseRateProvider
+{
+    bool Enabled { get; }
+
+    bool TryGetBaseRate(string symbol, DateTime asOf, out BaseRate? baseRate);
+}

--- a/src/AiHedgeFund.Contracts/Model/BaseRate.cs
+++ b/src/AiHedgeFund.Contracts/Model/BaseRate.cs
@@ -1,0 +1,81 @@
+using System.Globalization;
+
+namespace AiHedgeFund.Contracts.Model;
+
+/// <summary>
+/// A historical base rate for a (symbol, date, horizon): the calibrated forward-return
+/// distribution of the cohort of historical analogs. Purely advisory context — it never
+/// changes an agent's decision, it only grounds the agent's reasoning in what analogous
+/// setups actually did next.
+/// </summary>
+public sealed class BaseRate
+{
+    public required string Asset { get; init; }
+    public required string AsOf { get; init; }
+    public int Horizon { get; init; }
+
+    public double MedianPct { get; init; }
+    public double P10Pct { get; init; }
+    public double P90Pct { get; init; }
+
+    public int? N { get; init; }
+    public double? Coverage { get; init; }
+    public int? CoverageN { get; init; }
+    public bool Calibrated { get; init; }
+    public string Source { get; init; } = "chartlibrary:cohort_analyze";
+
+    private static string Pct(double value) =>
+        value.ToString("+0.0;-0.0", CultureInfo.InvariantCulture) + "%";
+
+    private static string Count(int value) =>
+        value.ToString("N0", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// One plain-English line suitable for injecting into an LLM prompt as grounding context.
+    /// </summary>
+    public string ToContextLine()
+    {
+        var kind = Calibrated ? "calibrated" : "raw";
+        var line = $"Historical base rate for {Asset} as of {AsOf} ({Horizon}-day horizon): " +
+                   $"median {Pct(MedianPct)}, {kind} 80% band [{Pct(P10Pct)}, {Pct(P90Pct)}]";
+
+        if (N is > 0)
+            line += $" from {Count(N.Value)} analogous setups";
+
+        if (Coverage is { } cov && CoverageN is > 0)
+        {
+            var covPct = (cov * 100).ToString("0.0", CultureInfo.InvariantCulture);
+            line += $"; calibration held {covPct}% across {Count(CoverageN.Value)} cases";
+        }
+
+        return line + ". Context only, not a forecast.";
+    }
+
+    /// <summary>
+    /// Returns an advisory note when a directional signal runs counter to a clearly-signed
+    /// base rate, otherwise null. This is a reality-check the caller may append to its
+    /// reasoning — it is informational and must not change the signal itself.
+    /// </summary>
+    public string? AssessConflict(string? signal)
+    {
+        const double flat = 0.10; // |median| below this is treated as no directional lean
+
+        var s = signal?.Trim().ToLowerInvariant();
+        var up = s is "bullish" or "buy" or "long";
+        var down = s is "bearish" or "sell" or "short";
+        if (!up && !down)
+            return null;
+
+        if (Math.Abs(MedianPct) < flat)
+            return null;
+
+        var against = (up && MedianPct < 0) || (down && MedianPct > 0);
+        if (!against)
+            return null;
+
+        var cohort = N is > 0 ? $" across {Count(N.Value)} analogous setups" : string.Empty;
+        return $"Base-rate reality-check: this {s} call runs counter to the historical base rate " +
+               $"(median {Pct(MedianPct)} over {Horizon} days{cohort}). Historical context only, " +
+               "not a directional forecast — the signal above is unchanged.";
+    }
+}

--- a/src/AiHedgeFund.Data/ChartLibrary/BaseRateParser.cs
+++ b/src/AiHedgeFund.Data/ChartLibrary/BaseRateParser.cs
@@ -1,0 +1,182 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using AiHedgeFund.Contracts.Model;
+
+namespace AiHedgeFund.Data.ChartLibrary;
+
+/// <summary>
+/// Parses a Chart Library cohort_analyze response into a <see cref="BaseRate"/>.
+/// Deliberately defensive: the response envelope shape is not contractually fixed,
+/// so it walks the whole tree, prefers the conformally calibrated band over the raw
+/// one, and matches the requested horizon on a digit boundary. Any malformed or
+/// missing data yields null rather than throwing.
+/// </summary>
+public static class BaseRateParser
+{
+    private static readonly string[] CountNames =
+        { "cohort_size", "n_matches", "n_cohort", "n", "count", "sample_size" };
+
+    public static BaseRate? Parse(string json, string asset, string asOf, int horizon)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return ParseRoot(doc.RootElement, asset, asOf, horizon);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static BaseRate? ParseRoot(JsonElement root, string asset, string asOf, int horizon)
+    {
+        var found = FindDistribution(root, horizon);
+        if (found is null)
+            return null;
+
+        var (path, dist) = found.Value;
+        var center = Center(dist);
+        if (center is null)
+            return null;
+        if (!TryGetNum(dist, "p10", out var p10) || !TryGetNum(dist, "p90", out var p90))
+            return null;
+
+        double? coverage = null;
+        int? coverageN = null;
+        var calBlock = FindCalibration(root);
+        if (calBlock is { } cal)
+        {
+            if (TryGetNum(cal, "empirical_coverage", out var cov) ||
+                TryGetNum(cal, "observed_coverage", out cov))
+                coverage = cov;
+            if (TryGetInt(cal, "sample_size", out var cn) ||
+                TryGetInt(cal, "n", out cn) ||
+                TryGetInt(cal, "coverage_n", out cn))
+                coverageN = cn;
+        }
+
+        return new BaseRate
+        {
+            Asset = asset,
+            AsOf = asOf,
+            Horizon = horizon,
+            MedianPct = center.Value,
+            P10Pct = p10,
+            P90Pct = p90,
+            N = FindInt(root, CountNames),
+            Coverage = coverage,
+            CoverageN = coverageN,
+            Calibrated = path.ToLowerInvariant().Contains("calibrated_return_pct"),
+        };
+    }
+
+    private static (string Path, JsonElement Dist)? FindDistribution(JsonElement root, int horizon)
+    {
+        (string, JsonElement)? best = null;
+        var bestScore = -1;
+        var htok = horizon.ToString(CultureInfo.InvariantCulture);
+        // Digit-boundary match so horizon 1 doesn't also match a "/10" path segment.
+        var horizonRe = new Regex($@"(?<!\d){Regex.Escape(htok)}(?!\d)");
+
+        foreach (var (p, d) in Walk(root, ""))
+        {
+            if (!IsDistribution(d))
+                continue;
+
+            var lp = p.ToLowerInvariant();
+            var score = 0;
+            if (lp.Contains("calibrated_return_pct"))
+                score += 4;
+            else if (lp.Contains("return_pct"))
+                score += 2;
+            if (horizonRe.IsMatch(lp))
+                score += 3;
+
+            if (score > bestScore)
+            {
+                best = (p, d);
+                bestScore = score;
+            }
+        }
+
+        return best;
+    }
+
+    private static IEnumerable<(string Path, JsonElement Obj)> Walk(JsonElement el, string path)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.Object:
+                yield return (path, el);
+                foreach (var prop in el.EnumerateObject())
+                    foreach (var item in Walk(prop.Value, $"{path}/{prop.Name}"))
+                        yield return item;
+                break;
+            case JsonValueKind.Array:
+                var i = 0;
+                foreach (var v in el.EnumerateArray())
+                {
+                    foreach (var item in Walk(v, $"{path}/{i}"))
+                        yield return item;
+                    i++;
+                }
+                break;
+        }
+    }
+
+    private static bool IsDistribution(JsonElement d) =>
+        Has(d, "p10") && Has(d, "p90") &&
+        (Has(d, "p50") || Has(d, "median") || Has(d, "mean"));
+
+    private static double? Center(JsonElement d)
+    {
+        if (TryGetNum(d, "p50", out var v)) return v;
+        if (TryGetNum(d, "median", out v)) return v;
+        if (TryGetNum(d, "mean", out v)) return v;
+        return null;
+    }
+
+    private static int? FindInt(JsonElement root, string[] names)
+    {
+        foreach (var (_, d) in Walk(root, ""))
+            foreach (var nm in names)
+                if (TryGetInt(d, nm, out var v) && v > 0)
+                    return v;
+        return null;
+    }
+
+    private static JsonElement? FindCalibration(JsonElement root)
+    {
+        foreach (var (p, d) in Walk(root, ""))
+            if (p.ToLowerInvariant().EndsWith("/calibration") &&
+                (Has(d, "empirical_coverage") || Has(d, "calibrated_coverage") || Has(d, "observed_coverage")))
+                return d;
+        return null;
+    }
+
+    private static bool Has(JsonElement d, string name) =>
+        d.ValueKind == JsonValueKind.Object && d.TryGetProperty(name, out _);
+
+    private static bool TryGetNum(JsonElement d, string name, out double value)
+    {
+        value = 0;
+        return d.ValueKind == JsonValueKind.Object &&
+               d.TryGetProperty(name, out var p) &&
+               p.ValueKind == JsonValueKind.Number &&
+               p.TryGetDouble(out value);
+    }
+
+    private static bool TryGetInt(JsonElement d, string name, out int value)
+    {
+        value = 0;
+        return d.ValueKind == JsonValueKind.Object &&
+               d.TryGetProperty(name, out var p) &&
+               p.ValueKind == JsonValueKind.Number &&
+               p.TryGetInt32(out value);
+    }
+}

--- a/src/AiHedgeFund.Data/ChartLibrary/ChartLibraryBaseRateProvider.cs
+++ b/src/AiHedgeFund.Data/ChartLibrary/ChartLibraryBaseRateProvider.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using AiHedgeFund.Contracts;
+using AiHedgeFund.Contracts.Model;
+using Microsoft.Extensions.Logging;
+
+namespace AiHedgeFund.Data.ChartLibrary;
+
+/// <summary>
+/// Degrade-safe client over Chart Library's cohort_analyze endpoint. A failed or
+/// disabled lookup returns false with a null base rate and never throws — grounding
+/// is advisory and must never block the trading flow. Results (including negative
+/// ones) are cached per run so a slow endpoint is hit at most once per (symbol, date).
+/// </summary>
+public sealed class ChartLibraryBaseRateProvider : IBaseRateProvider
+{
+    private readonly HttpClient _client;
+    private readonly GroundingOptions _options;
+    private readonly ILogger<ChartLibraryBaseRateProvider> _logger;
+    private readonly ConcurrentDictionary<string, BaseRate?> _cache = new();
+
+    public ChartLibraryBaseRateProvider(
+        IHttpClientFactory clientFactory,
+        GroundingOptions options,
+        ILogger<ChartLibraryBaseRateProvider> logger)
+    {
+        _client = clientFactory.CreateClient("ChartLibrary");
+        _options = options;
+        _logger = logger;
+    }
+
+    public bool Enabled => _options.Active;
+
+    public bool TryGetBaseRate(string symbol, DateTime asOf, out BaseRate? baseRate)
+    {
+        baseRate = null;
+        if (!Enabled || string.IsNullOrWhiteSpace(symbol))
+            return false;
+
+        var sym = symbol.Trim().ToUpperInvariant();
+        var day = asOf.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var horizon = _options.OverfitHorizon;
+        var cacheKey = $"{sym}|{day}|{horizon}";
+
+        var result = _cache.GetOrAdd(cacheKey, _ => Fetch(sym, day, horizon));
+        baseRate = result;
+        return result is not null;
+    }
+
+    private BaseRate? Fetch(string symbol, string day, int horizon)
+    {
+        try
+        {
+            var body = BuildRequestBody(symbol, day);
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var request = new HttpRequestMessage(HttpMethod.Post, "api/v1/cohort_analyze")
+            {
+                Content = content
+            };
+            if (_options.HasKey)
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {_options.ApiKey}");
+
+            var timeout = _options.TimeoutSeconds <= 0 ? 8.0 : _options.TimeoutSeconds;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+
+            // Synchronous over the async API to match the codebase's IHttpLib pattern.
+            using var response = _client.SendAsync(request, cts.Token).GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Base-rate grounding: HTTP {Status} for {Symbol} {Day}",
+                    (int)response.StatusCode, symbol, day);
+                return null;
+            }
+
+            var json = response.Content.ReadAsStringAsync(cts.Token).GetAwaiter().GetResult();
+            return BaseRateParser.Parse(json, symbol, day, horizon);
+        }
+        catch (Exception ex)
+        {
+            // Degrade-safe by contract: any failure leaves the agent exactly as it is today.
+            _logger.LogDebug(ex, "Base-rate grounding unavailable for {Symbol} {Day}", symbol, day);
+            return null;
+        }
+    }
+
+    private string BuildRequestBody(string symbol, string day)
+    {
+        var body = new
+        {
+            anchor = new { symbol, date = day, timeframe = _options.Timeframe },
+            horizons = _options.Horizons,
+            options = new { exclude_same_symbol_days = _options.ExcludeSameSymbolDays }
+        };
+        return JsonSerializer.Serialize(body);
+    }
+}

--- a/src/AiHedgeFund.Data/ChartLibrary/GroundingOptions.cs
+++ b/src/AiHedgeFund.Data/ChartLibrary/GroundingOptions.cs
@@ -1,0 +1,25 @@
+namespace AiHedgeFund.Data.ChartLibrary;
+
+/// <summary>
+/// Configuration for optional historical base-rate grounding. Off by default; the
+/// provider is only <see cref="Active"/> when grounding is explicitly enabled AND an
+/// API key is present. Bound from the "Grounding" configuration section.
+/// </summary>
+public sealed class GroundingOptions
+{
+    public const string SectionName = "Grounding";
+
+    public bool Enabled { get; set; } = false;
+    public string BaseUrl { get; set; } = "https://chartlibrary.io";
+    public string? ApiKey { get; set; }
+    public string Timeframe { get; set; } = "rth";
+    public int[] Horizons { get; set; } = { 1, 5, 10 };
+    public int OverfitHorizon { get; set; } = 5;
+    public double TimeoutSeconds { get; set; } = 8.0;
+    public bool ExcludeSameSymbolDays { get; set; } = true;
+
+    public bool HasKey => !string.IsNullOrWhiteSpace(ApiKey);
+
+    /// <summary>Grounding only does anything when both enabled and keyed.</summary>
+    public bool Active => Enabled && HasKey;
+}

--- a/src/AiHedgeFund.Tests/BaseRateTests.cs
+++ b/src/AiHedgeFund.Tests/BaseRateTests.cs
@@ -1,0 +1,421 @@
+using System.Net;
+using AiHedgeFund.Contracts.Model;
+using AiHedgeFund.Data.ChartLibrary;
+using AiHedgeFund.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AiHedgeFund.Tests;
+
+/// <summary>
+/// Covers the optional base-rate grounding feature end to end: the pure <see cref="BaseRate"/>
+/// model (context line + conflict advisory), the defensive <see cref="BaseRateParser"/>, and the
+/// degrade-safe <see cref="ChartLibraryBaseRateProvider"/>. The provider must NEVER throw and must
+/// be a clean no-op unless explicitly enabled with a key — that contract is what keeps grounding
+/// from ever blocking the trading flow.
+/// </summary>
+[TestFixture]
+public class BaseRateTests
+{
+    private static readonly DateTime Day = new(2026, 5, 9);
+    private const string DayStr = "2026-05-09";
+
+    // A realistic-shape cohort_analyze envelope: raw + conformally calibrated bands per horizon,
+    // a cohort_size at the root, and a calibration block on the 5-day horizon.
+    private const string SyntheticPayload = """
+        {
+          "anchor": { "symbol": "NVDA", "date": "2026-05-09" },
+          "cohort_size": 348,
+          "horizons": {
+            "1": {
+              "return_pct": { "p10": -2.1, "p50": 0.3, "p90": 2.7 },
+              "calibrated_return_pct": { "p10": -2.6, "p50": 0.3, "p90": 3.2 }
+            },
+            "5": {
+              "return_pct": { "p10": -5.4, "p50": 1.2, "p90": 7.1 },
+              "calibrated_return_pct": { "p10": -6.8, "p50": 1.4, "p90": 8.9 },
+              "calibration": { "empirical_coverage": 0.808, "sample_size": 302880 }
+            },
+            "10": {
+              "return_pct": { "p10": -8.0, "p50": 2.0, "p90": 11.0 },
+              "calibrated_return_pct": { "p10": -9.5, "p50": 2.2, "p90": 12.5 }
+            }
+          }
+        }
+        """;
+
+    // Only horizons 1 and 10 — used to prove horizon 1 does not bleed into the "10" path segment.
+    private const string HorizonCollisionPayload = """
+        {
+          "cohort_size": 50,
+          "horizons": {
+            "1":  { "calibrated_return_pct": { "p10": -1.0, "p50": 0.5, "p90": 1.5 } },
+            "10": { "calibrated_return_pct": { "p10": -9.0, "p50": 5.0, "p90": 14.0 } }
+          }
+        }
+        """;
+
+    // ---- helpers -------------------------------------------------------
+
+    private static GroundingOptions ActiveOptions(int horizon = 5) => new()
+    {
+        Enabled = true,
+        ApiKey = "test-key",
+        Timeframe = "rth",
+        Horizons = new[] { 1, 5, 10 },
+        OverfitHorizon = horizon,
+        ExcludeSameSymbolDays = true
+    };
+
+    private static ChartLibraryBaseRateProvider NewProvider(GroundingOptions options, HttpMessageHandler handler)
+    {
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://chartlibrary.test/") };
+        var factory = new FakeHttpClientFactory(client);
+        return new ChartLibraryBaseRateProvider(factory, options, NullLogger<ChartLibraryBaseRateProvider>.Instance);
+    }
+
+    private static BaseRate Rate(double median, int? n = null) => new()
+    {
+        Asset = "T",
+        AsOf = DayStr,
+        Horizon = 5,
+        MedianPct = median,
+        P10Pct = median - 3,
+        P90Pct = median + 3,
+        N = n,
+        Calibrated = true
+    };
+
+    /// <summary>Records what the provider actually sent and returns a canned response.</summary>
+    private sealed class CapturingHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastBody { get; private set; }
+        public string? LastAuthorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastRequest = request;
+            LastAuthorization = request.Headers.TryGetValues("Authorization", out var v) ? string.Join(",", v) : null;
+            LastBody = request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
+            return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+        }
+    }
+
+    /// <summary>Always throws — exercises the degrade-safe path.</summary>
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            throw new HttpRequestException("boom");
+        }
+    }
+
+    // ==== BaseRate model ===============================================
+
+    [Test]
+    public void ToContextLine_Calibrated_IncludesBandCohortAndCoverage()
+    {
+        var r = new BaseRate
+        {
+            Asset = "NVDA", AsOf = DayStr, Horizon = 5,
+            MedianPct = 1.4, P10Pct = -6.8, P90Pct = 8.9,
+            N = 348, Coverage = 0.808, CoverageN = 302880, Calibrated = true
+        };
+
+        var line = r.ToContextLine();
+
+        Assert.That(line, Does.Contain("NVDA"));
+        Assert.That(line, Does.Contain("5-day horizon"));
+        Assert.That(line, Does.Contain("median +1.4%"));
+        Assert.That(line, Does.Contain("calibrated 80% band [-6.8%, +8.9%]"));
+        Assert.That(line, Does.Contain("from 348 analogous setups"));
+        Assert.That(line, Does.Contain("calibration held 80.8% across 302,880 cases"));
+        Assert.That(line, Does.Contain("Context only, not a forecast."));
+    }
+
+    [Test]
+    public void ToContextLine_RawWithoutCoverageOrCohort_OmitsThoseClauses()
+    {
+        var r = new BaseRate
+        {
+            Asset = "AAPL", AsOf = "2026-01-02", Horizon = 10,
+            MedianPct = -0.3, P10Pct = -5.0, P90Pct = 4.0,
+            Calibrated = false
+        };
+
+        var line = r.ToContextLine();
+
+        Assert.That(line, Does.Contain("raw 80% band [-5.0%, +4.0%]"));
+        Assert.That(line, Does.Contain("median -0.3%"));
+        Assert.That(line, Does.Not.Contain("analogous setups"));
+        Assert.That(line, Does.Not.Contain("calibration held"));
+    }
+
+    [Test]
+    public void AssessConflict_BullishAgainstNegativeMedian_ReturnsNoteWithCohort()
+    {
+        var note = Rate(median: -2.0, n: 100).AssessConflict("bullish");
+
+        Assert.That(note, Is.Not.Null);
+        Assert.That(note, Does.Contain("runs counter"));
+        Assert.That(note, Does.Contain("this bullish call"));
+        Assert.That(note, Does.Contain("across 100 analogous setups"));
+        Assert.That(note, Does.Contain("the signal above is unchanged"));
+    }
+
+    [Test]
+    public void AssessConflict_BearishAgainstPositiveMedian_ReturnsNote()
+    {
+        var note = Rate(median: 2.0).AssessConflict("SELL");
+
+        Assert.That(note, Is.Not.Null);
+        Assert.That(note, Does.Contain("this sell call"));
+    }
+
+    [Test]
+    public void AssessConflict_SignalAgreesWithBaseRate_ReturnsNull()
+    {
+        Assert.That(Rate(median: 2.0).AssessConflict("bullish"), Is.Null);
+        Assert.That(Rate(median: -2.0).AssessConflict("bearish"), Is.Null);
+    }
+
+    [Test]
+    public void AssessConflict_FlatMedian_ReturnsNull()
+    {
+        Assert.That(Rate(median: 0.05).AssessConflict("bearish"), Is.Null);
+        Assert.That(Rate(median: -0.09).AssessConflict("bullish"), Is.Null);
+    }
+
+    [Test]
+    public void AssessConflict_NonDirectionalOrMissingSignal_ReturnsNull()
+    {
+        Assert.That(Rate(median: -5.0).AssessConflict("hold"), Is.Null);
+        Assert.That(Rate(median: -5.0).AssessConflict(null), Is.Null);
+        Assert.That(Rate(median: -5.0).AssessConflict(""), Is.Null);
+        Assert.That(Rate(median: -5.0).AssessConflict("neutral"), Is.Null);
+    }
+
+    [Test]
+    public void AssessConflict_SignalSynonyms_AreCaseInsensitive()
+    {
+        Assert.That(Rate(median: -3.0).AssessConflict("LONG"), Is.Not.Null);
+        Assert.That(Rate(median: -3.0).AssessConflict("Buy"), Is.Not.Null);
+        Assert.That(Rate(median: 3.0).AssessConflict("short"), Is.Not.Null);
+    }
+
+    // ==== BaseRateParser ===============================================
+
+    [Test]
+    public void Parse_PrefersCalibratedBand_MatchesHorizon_AndPullsCohortAndCoverage()
+    {
+        var r = BaseRateParser.Parse(SyntheticPayload, "NVDA", DayStr, horizon: 5);
+
+        Assert.That(r, Is.Not.Null);
+        Assert.That(r!.Asset, Is.EqualTo("NVDA"));
+        Assert.That(r.AsOf, Is.EqualTo(DayStr));
+        Assert.That(r.Horizon, Is.EqualTo(5));
+        Assert.That(r.Calibrated, Is.True);
+        // Calibrated 5-day p50 = 1.4 (not the raw 1.2, not the 1-day or 10-day band).
+        Assert.That(r.MedianPct, Is.EqualTo(1.4).Within(1e-9));
+        Assert.That(r.P10Pct, Is.EqualTo(-6.8).Within(1e-9));
+        Assert.That(r.P90Pct, Is.EqualTo(8.9).Within(1e-9));
+        Assert.That(r.N, Is.EqualTo(348));
+        Assert.That(r.Coverage, Is.EqualTo(0.808).Within(1e-9));
+        Assert.That(r.CoverageN, Is.EqualTo(302880));
+    }
+
+    [Test]
+    public void Parse_HorizonOne_DoesNotMatchTheTenSegment()
+    {
+        var r = BaseRateParser.Parse(HorizonCollisionPayload, "NVDA", DayStr, horizon: 1);
+
+        Assert.That(r, Is.Not.Null);
+        // Must pick the "1" block (median 0.5), never the "10" block (median 5.0).
+        Assert.That(r!.MedianPct, Is.EqualTo(0.5).Within(1e-9));
+    }
+
+    [Test]
+    public void Parse_RawOnlyPayload_ReportsNotCalibrated()
+    {
+        const string rawOnly = """
+            { "cohort_size": 20, "horizons": { "5": { "return_pct": { "p10": -4.0, "p50": 0.8, "p90": 5.0 } } } }
+            """;
+
+        var r = BaseRateParser.Parse(rawOnly, "MSFT", DayStr, horizon: 5);
+
+        Assert.That(r, Is.Not.Null);
+        Assert.That(r!.Calibrated, Is.False);
+        Assert.That(r.MedianPct, Is.EqualTo(0.8).Within(1e-9));
+        Assert.That(r.N, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Parse_DistributionWithMeanButNoMedian_UsesMeanAsCenter()
+    {
+        const string meanOnly = """
+            { "horizons": { "5": { "calibrated_return_pct": { "p10": -2.0, "mean": 0.9, "p90": 3.0 } } } }
+            """;
+
+        var r = BaseRateParser.Parse(meanOnly, "TSLA", DayStr, horizon: 5);
+
+        Assert.That(r, Is.Not.Null);
+        Assert.That(r!.MedianPct, Is.EqualTo(0.9).Within(1e-9));
+    }
+
+    [Test]
+    public void Parse_EmptyOrWhitespaceJson_ReturnsNull()
+    {
+        Assert.That(BaseRateParser.Parse("", "NVDA", DayStr, 5), Is.Null);
+        Assert.That(BaseRateParser.Parse("   ", "NVDA", DayStr, 5), Is.Null);
+    }
+
+    [Test]
+    public void Parse_MalformedJson_ReturnsNull()
+    {
+        Assert.That(BaseRateParser.Parse("{not valid json", "NVDA", DayStr, 5), Is.Null);
+    }
+
+    [Test]
+    public void Parse_NoDistributionPresent_ReturnsNull()
+    {
+        Assert.That(BaseRateParser.Parse("""{ "foo": { "bar": 1 } }""", "NVDA", DayStr, 5), Is.Null);
+    }
+
+    // ==== ChartLibraryBaseRateProvider =================================
+
+    [Test]
+    public void Provider_WhenDisabled_IsNoOp_AndNeverCallsHttp()
+    {
+        var options = new GroundingOptions { Enabled = false, ApiKey = "test-key" }; // Active == false
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(options, handler);
+
+        Assert.That(provider.Enabled, Is.False);
+
+        var ok = provider.TryGetBaseRate("NVDA", Day, out var br);
+
+        Assert.That(ok, Is.False);
+        Assert.That(br, Is.Null);
+        Assert.That(handler.Calls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Provider_WhenEnabledWithoutKey_IsNoOp()
+    {
+        var options = new GroundingOptions { Enabled = true, ApiKey = null }; // HasKey == false
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(options, handler);
+
+        Assert.That(provider.Enabled, Is.False);
+        Assert.That(provider.TryGetBaseRate("NVDA", Day, out _), Is.False);
+        Assert.That(handler.Calls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Provider_EmptySymbol_ReturnsFalse_WithoutHttp()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        var ok = provider.TryGetBaseRate("   ", Day, out var br);
+
+        Assert.That(ok, Is.False);
+        Assert.That(br, Is.Null);
+        Assert.That(handler.Calls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Provider_GoodResponse_ReturnsParsedBaseRate_AndUppercasesSymbol()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(ActiveOptions(horizon: 5), handler);
+
+        var ok = provider.TryGetBaseRate("nvda", Day, out var br);
+
+        Assert.That(ok, Is.True);
+        Assert.That(br, Is.Not.Null);
+        Assert.That(br!.Asset, Is.EqualTo("NVDA"));
+        Assert.That(br.AsOf, Is.EqualTo(DayStr));
+        Assert.That(br.Horizon, Is.EqualTo(5));
+        Assert.That(br.MedianPct, Is.EqualTo(1.4).Within(1e-9));
+        Assert.That(br.Calibrated, Is.True);
+        Assert.That(br.N, Is.EqualTo(348));
+        Assert.That(handler.Calls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Provider_SendsBearerKeyAndPostsCohortAnalyzeBody()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        provider.TryGetBaseRate("NVDA", Day, out _);
+
+        Assert.That(handler.LastAuthorization, Is.EqualTo("Bearer test-key"));
+        Assert.That(handler.LastRequest!.Method, Is.EqualTo(HttpMethod.Post));
+        Assert.That(handler.LastRequest.RequestUri!.AbsolutePath, Does.EndWith("/api/v1/cohort_analyze"));
+        Assert.That(handler.LastBody, Does.Contain("\"symbol\":\"NVDA\""));
+        Assert.That(handler.LastBody, Does.Contain("\"date\":\"2026-05-09\""));
+        Assert.That(handler.LastBody, Does.Contain("\"timeframe\":\"rth\""));
+        Assert.That(handler.LastBody, Does.Contain("\"horizons\":[1,5,10]"));
+        Assert.That(handler.LastBody, Does.Contain("\"exclude_same_symbol_days\":true"));
+    }
+
+    [Test]
+    public void Provider_NonSuccessStatus_DegradesToFalseNull()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.InternalServerError, "{}");
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        var ok = provider.TryGetBaseRate("NVDA", Day, out var br);
+
+        Assert.That(ok, Is.False);
+        Assert.That(br, Is.Null);
+        Assert.That(handler.Calls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Provider_WhenHttpThrows_NeverThrows_AndReturnsFalseNull()
+    {
+        var handler = new ThrowingHandler();
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        var ok = true;
+        BaseRate? br = null;
+        Assert.DoesNotThrow(() => ok = provider.TryGetBaseRate("NVDA", Day, out br));
+
+        Assert.That(ok, Is.False);
+        Assert.That(br, Is.Null);
+        Assert.That(handler.Calls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Provider_CachesPositiveResult_HitsEndpointAtMostOnce()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, SyntheticPayload);
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        provider.TryGetBaseRate("NVDA", Day, out var first);
+        provider.TryGetBaseRate("NVDA", Day, out var second);
+
+        Assert.That(handler.Calls, Is.EqualTo(1));
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void Provider_CachesNegativeResult_DoesNotRetryWithinRun()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.InternalServerError, "{}");
+        var provider = NewProvider(ActiveOptions(), handler);
+
+        provider.TryGetBaseRate("NVDA", Day, out _);
+        provider.TryGetBaseRate("NVDA", Day, out _);
+
+        Assert.That(handler.Calls, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **optional, off-by-default** capability that grounds each agent's
reasoning in a **historical base rate**: for the `(ticker, decision date)` an
agent is evaluating, it looks up the calibrated forward-return distribution of
historically analogous setups (median + 80% band) from
[Chart Library](https://chartlibrary.io) and surfaces one plain-English line of
context. It is **purely advisory** — it never changes an agent's buy/hold/sell
signal or confidence — and it is **degrade-safe**: with the feature off (the
default), no key configured, or an unreachable endpoint, the program behaves
exactly as it does today.

> _Disclosure: I'm the author of the analog service this talks to
> (chartlibrary.io). The integration is generic, off by default, and degrades
> to a silent no-op with no key — but flagging the affiliation up front so you
> can weigh it._

## What it does

When enabled, the base rate is threaded into each agent via `AgentInput` and
injected into the LLM prompt as advisory context, e.g.:

> Historical base rate for NVDA as of 2026-05-09 (5-day horizon): median +1.4%,
> calibrated 80% band [-6.8%, +8.9%] from 348 analogous setups; calibration
> held 80.8% across 302,880 cases. Context only, not a forecast.

When an agent's signal runs *counter* to a clearly-signed base rate,
`PortfolioManager` appends a one-line reality-check note to the reasoning. The
signal and confidence are never altered.

## No look-ahead by construction

`PortfolioManager` anchors the base rate on the **latest priced bar** (the
decision date), falling back to the workflow end date — the cohort of analogs
is drawn only from earlier data. Everything surfaced is a realized historical
base rate, never a forecast.

## How to enable (off by default)

Add a `Grounding` section to `appsettings.json` and supply a Chart Library API
key (full details + the option table are in the README):

```json
{ "Grounding": { "Enabled": true, "ApiKey": "your-chartlibrary-api-key" } }
```

The key and base URL can also come from the `CHART_LIBRARY_API_KEY` /
`CHART_LIBRARY_API_URL` environment variables (which override config).
Grounding activates **only** when `Enabled` is `true` **and** a key is present;
otherwise it is a clean no-op.

## Files

**New — `AiHedgeFund.Contracts`**
- `Model/BaseRate.cs` — advisory value object (`ToContextLine()` + `AssessConflict()`)
- `IBaseRateProvider.cs` — degrade-safe provider abstraction

**New — `AiHedgeFund.Data`**
- `ChartLibrary/GroundingOptions.cs` — bound from the `Grounding` section; `Active` only when enabled + keyed
- `ChartLibrary/BaseRateParser.cs` — defensive `cohort_analyze` parser (prefers the conformally calibrated band, digit-boundary horizon match, null on malformed/missing data)
- `ChartLibrary/ChartLibraryBaseRateProvider.cs` — degrade-safe client (per-lookup timeout, per-run cache, never throws)

**Wiring**
- `AgentInput` — new optional `BaseRate?` (defaulted, so existing construction sites are unaffected)
- 6 agents + `LlmTradeSignalGenerator` — surface the base rate as prompt context when present, ignore it when null
- `PortfolioManager` — no-lookahead lookup + advisory note
- `Program.cs` — registers the provider + a named `ChartLibrary` `HttpClient`, reads the `Grounding` section and `CHART_LIBRARY_API_KEY` / `CHART_LIBRARY_API_URL` overrides

**Tests**
- `AiHedgeFund.Tests/BaseRateTests.cs`

**Docs**
- `README.md` — new "Optional: Historical Base-Rate Grounding (off by default)" section

## Testing

`BaseRateTests.cs` adds 24 NUnit tests across three areas (all green locally via `dotnet test` on .NET 10 — the full solution passes 32/32 with no regressions to the existing suite):

- **`BaseRate` model** — context-line formatting (calibrated vs raw, with/without cohort + coverage clauses) and the conflict advisory (fires on bullish-vs-negative / bearish-vs-positive including the buy/sell/long/short synonyms; stays silent on agreement, a flat median, and non-directional or missing signals).
- **`BaseRateParser`** — calibrated-band preference, digit-boundary horizon matching (horizon `1` does not match a `/10` path segment), mean-as-center fallback, and null on empty/whitespace/malformed/no-distribution input.
- **`ChartLibraryBaseRateProvider`** — no-op when disabled or keyless, empty-symbol short-circuit, end-to-end parse of a good response (including symbol upper-casing), degrade-safe on a non-200 status and on a thrown exception, positive **and** negative per-run caching, and that it sends the `Bearer` key plus the correct `cohort_analyze` POST body.

## Non-goals / safety

Not a forecast and not a signal source. It never overrides an agent's decision,
and it is a no-op unless explicitly enabled with a key. The provider catches all
failures and returns "no base rate" rather than throwing, so grounding can never
block the trading flow.

Fixes https://github.com/riccardone/ai-hedge-fund-net/issues/3